### PR TITLE
Bump to 15.2.0 and format fluent calls for readability

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 	<artifactId>fess-ds-dropbox</artifactId>
 	<packaging>jar</packaging>
 	<name>Dropbox Data Store</name>
-	<version>15.1.1-SNAPSHOT</version>
+	<version>15.2.0-SNAPSHOT</version>
 	<scm>
 		<connection>scm:git:git@github.com:codelibs/fess-ds-dropbox.git</connection>
 		<developerConnection>scm:git:git@github.com:codelibs/fess-ds-dropbox.git</developerConnection>
@@ -14,7 +14,7 @@
 	<parent>
 		<groupId>org.codelibs.fess</groupId>
 		<artifactId>fess-parent</artifactId>
-		<version>15.1.0</version>
+		<version>15.2.0</version>
 		<relativePath />
 	</parent>
 	<properties>

--- a/src/main/java/org/codelibs/fess/ds/dropbox/DropboxClient.java
+++ b/src/main/java/org/codelibs/fess/ds/dropbox/DropboxClient.java
@@ -324,7 +324,10 @@ public class DropboxClient {
             throws DbxException {
         try (final DeferredFileOutputStream dfos =
                 new DeferredFileOutputStream(maxCachedContentSize, "crawler-DropboxClient-", ".out", SystemUtils.getJavaIoTmpDir())) {
-            teamClient.asAdmin(adminId).withPathRoot(PathRoot.namespaceId(teamFolderId)).files().download(file.getPathDisplay())
+            teamClient.asAdmin(adminId)
+                    .withPathRoot(PathRoot.namespaceId(teamFolderId))
+                    .files()
+                    .download(file.getPathDisplay())
                     .download(dfos);
             dfos.flush();
             if (dfos.isInMemory()) {

--- a/src/main/java/org/codelibs/fess/ds/dropbox/DropboxDataStore.java
+++ b/src/main/java/org/codelibs/fess/ds/dropbox/DropboxDataStore.java
@@ -559,7 +559,11 @@ public class DropboxDataStore extends AbstractDataStore {
     protected String getFileContents(final InputStream in, final FileMetadata file, final String mimeType, final String url,
             final boolean ignoreError) {
         try {
-            return ComponentUtil.getExtractorFactory().builder(in, null).mimeType(mimeType).extractorName(extractorName).extract()
+            return ComponentUtil.getExtractorFactory()
+                    .builder(in, null)
+                    .mimeType(mimeType)
+                    .extractorName(extractorName)
+                    .extract()
                     .getContent();
         } catch (final Exception e) {
             if (!ignoreError && !ComponentUtil.getFessConfig().isCrawlerIgnoreContentException()) {

--- a/src/main/java/org/codelibs/fess/ds/dropbox/DropboxPaperDataStore.java
+++ b/src/main/java/org/codelibs/fess/ds/dropbox/DropboxPaperDataStore.java
@@ -451,7 +451,11 @@ public class DropboxPaperDataStore extends AbstractDataStore {
      */
     protected String getPaperContents(final InputStream in, final String mimeType, final String url, final boolean ignoreError) {
         try {
-            return ComponentUtil.getExtractorFactory().builder(in, null).mimeType(mimeType).extractorName(extractorName).extract()
+            return ComponentUtil.getExtractorFactory()
+                    .builder(in, null)
+                    .mimeType(mimeType)
+                    .extractorName(extractorName)
+                    .extract()
                     .getContent();
         } catch (final Exception e) {
             if (!ignoreError && !ComponentUtil.getFessConfig().isCrawlerIgnoreContentException()) {


### PR DESCRIPTION
This pull request updates the Dropbox data store to align with the latest parent version and improves code readability by refactoring chained method calls for better clarity. The most significant changes include version bumps in `pom.xml` and formatting improvements in content extraction and file download logic.

Version updates:

* Updated the `fess-ds-dropbox` module version to `15.2.0-SNAPSHOT` in `pom.xml`.
* Updated the parent `fess-parent` version to `15.2.0` in `pom.xml`.

Code readability improvements:

* Refactored chained method calls in `DropboxDataStore.java` (`getFileContents`) to use multi-line formatting for better readability.
* Refactored chained method calls in `DropboxPaperDataStore.java` (`getPaperContents`) to use multi-line formatting for better readability.
* Improved formatting of chained Dropbox API calls in `DropboxClient.java` (`getTeamFileInputStream`) for clarity.